### PR TITLE
Fixes #7 -- Generates Swragger documentation from rest endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,19 @@ cartridges=builder, camelrs
 Define this properties in you sculptor-generator.properties to control CamelRS
 endpoints generation.
 
-*deployment.contextPath* - controls context path CamelRS will be using to bind it services to.
-This is a required property. Set it to context path you're planning to deploy resulting WAR file to.
+*deployment.contextRoot* - controls context root CamelRS will be using to bind it services to.
+This is a required property. Set it to context root you're planning to deploy resulting WAR file to.
+
+*camelrs.restPath* - controls the path CamelRS will bind rest services to.
+By default set to 'contextRoot'. Override it if you need different path for CamelRS services.
 
 *camelrs.idToEntityMappingMethod* - controls service method that will be used to map between ID and Entity.
 By default set to 'findById'. Override it if you're using another naming convention.
 
+## Example web.xml generator
+Some services (CamelRS for instance) require addtional setup done in web.xml. Example web.xml generator
+builds basic web.xml providing initial configuration for those services. It's located in src/generated/resources directory. 
+Copy web_example.xml to src/main/webapp/WEB-INF/web.xml and edit it to fine tune it's parameters.
 
+*generate.web.example* - controls generation of web_example.xml file.
+By default set to 'true'. Set it to false to disable web_example.xml generation.

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
 	<properties>
 		<sculptor-version>3.1.0</sculptor-version>
 		<deltaspike.version>1.3.0</deltaspike.version>
+		<commons-lang-versions>3.4</commons-lang-versions>
 	</properties>
 
 	<build>
@@ -103,6 +104,11 @@
 			<artifactId>sculptor-generator-test-library</artifactId>
 			<version>${sculptor-version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${commons-lang-versions}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/sculptor/generator/cartridge/camelrs/ExampleWebXmlTmpl.xtend
+++ b/src/main/java/org/sculptor/generator/cartridge/camelrs/ExampleWebXmlTmpl.xtend
@@ -1,0 +1,79 @@
+package org.sculptor.generator.cartridge.camelrs
+
+import com.google.common.base.Supplier
+import javax.inject.Inject
+import org.sculptor.generator.ext.Helper
+import sculptormetamodel.Application
+import org.sculptor.generator.util.OutputSlot
+
+class ExampleWebXmlTmpl {
+	
+	@Inject extension Helper helper;
+	@Inject extension WebXmlHelper webXmlHelper
+
+	def webXml(Application it) {
+		fileOutput("web_example.xml", OutputSlot::TO_GEN_RESOURCES, '''
+		<?xml version="1.0" encoding="UTF-8"?>
+		<web-app>
+			«camelHttpServlet»
+			«camelSwaggerServlet»
+		</web-app>
+	''')
+	}
+	
+	def camelHttpServlet(Application it) '''
+		«servlet(
+			"CamelServlet",
+			"Camel Http Transport Servlet",
+			"org.apache.camel.component.servlet.CamelHttpTransportServlet", 1)»
+		
+		«servletMapping(
+			"CamelServlet",
+			"/" + restPath + "/*")»
+	'''
+	
+	def camelSwaggerServlet(Application it) '''
+		«servlet(
+			"ApiDeclarationServlet",
+			"Camel Swagger API Servlet",
+			"org.apache.camel.component.swagger.DefaultCamelSwaggerServlet", 1, ['''
+				«initParam("base.path"			, restPath)»
+				«initParam("api.path"			, "api-docs")»
+				«initParam("api.version"		, "1.0.0")»
+				«initParam("api.title"			, "Documentation")»
+				«initParam("api.description"	, "Documentation")»
+			'''])»
+		
+		«servletMapping("ApiDeclarationServlet", "/api-docs/*")»
+	'''
+	
+	def servletMapping(String name, String pattern) '''
+		<servlet-mapping>
+			<servlet-name>«name»</servlet-name>
+			<url-pattern>«pattern»</url-pattern>
+		</servlet-mapping>
+	'''
+	
+	def servlet(String name, String displayName, String clazz, int load) {
+		servlet(name, displayName, clazz, load, null)
+	}
+	
+	def servlet(String name, String displayName, String clazz, int load, Supplier<String> initParams) '''
+		<servlet>
+			<display-name>«displayName»</display-name>
+			<servlet-name>«name»</servlet-name>
+			<servlet-class>«clazz»</servlet-class>
+			<load-on-startup>«load»</load-on-startup>
+			«IF initParams != null»
+			«initParams.get»
+			«ENDIF»
+		</servlet>
+	'''
+	
+	def initParam(String name, String value) '''
+		<init-param>
+			<param-name>«name»</param-name>
+			<param-value>«value»</param-value>
+		</init-param>
+	'''
+}

--- a/src/main/java/org/sculptor/generator/cartridge/camelrs/RootTmplExtension.xtend
+++ b/src/main/java/org/sculptor/generator/cartridge/camelrs/RootTmplExtension.xtend
@@ -1,0 +1,21 @@
+package org.sculptor.generator.cartridge.camelrs
+
+import org.sculptor.generator.chain.ChainOverride
+import org.sculptor.generator.template.RootTmpl
+import sculptormetamodel.Application
+import javax.inject.Inject
+
+@ChainOverride
+class RootTmplExtension extends RootTmpl {
+	
+	@Inject extension WebXmlHelper webXmlHelper
+	
+	@Inject ExampleWebXmlTmpl exampleWebXml
+	
+	override String root(Application it) '''
+		«next.root(it)»
+		«IF(webXmlSampleToBeGenerated)»
+			«exampleWebXml.webXml(it)»
+		«ENDIF»
+	'''		
+}

--- a/src/main/java/org/sculptor/generator/cartridge/camelrs/WebXmlHelper.xtend
+++ b/src/main/java/org/sculptor/generator/cartridge/camelrs/WebXmlHelper.xtend
@@ -1,0 +1,35 @@
+package org.sculptor.generator.cartridge.camelrs
+
+import javax.inject.Inject
+import org.sculptor.generator.ext.Properties
+import org.sculptor.generator.util.PropertiesBase
+
+class WebXmlHelper {
+	
+	@Inject extension Properties properties
+	@Inject extension PropertiesBase propertiesBase
+	
+	def isWebXmlSampleToBeGenerated() {
+		getBooleanProperty("generate.web.example", true)
+	}
+	
+	def getRestPath() {
+		getProperty("camelrs.restPath", "camel")
+	}
+	
+	def getContextRoot() {
+		getProperty("deployment.contextRoot", "context-path")
+	}
+	
+	def getContextPath() {
+		contextRoot + "/" + restPath
+	}
+	
+	def getBooleanProperty(String name, boolean defaultValue) {
+		if (!hasProperty(name)) {
+			defaultValue
+		} else {
+			properties.getBooleanProperty(name)
+		}
+	}
+}

--- a/src/test/java/org/sculptor/generator/cartridge/camelrs/ResourceTmplExtensionTest.xtend
+++ b/src/test/java/org/sculptor/generator/cartridge/camelrs/ResourceTmplExtensionTest.xtend
@@ -50,7 +50,8 @@ class ResourceTmplExtensionTest extends GeneratorTestBase {
 		val code = getFileText(TO_GEN_SRC + "/org/helloworld/planet/rest/PlanetResourceImpl.java");
 		assertContains(code, "abstract class")
 		assertContains(code, "protected abstract void createRouteDirectUpdate();")	
-		assertContains(code, "put(\"/\").type(PlanetForm.class).to(\"direct:update\")")
+		assertContains(code, "put(\"/\")")
+		assertContains(code, "type(PlanetForm.class).to(\"direct:update\")")
 	}
 	
 	@Test
@@ -58,7 +59,8 @@ class ResourceTmplExtensionTest extends GeneratorTestBase {
 		val code = getFileText(TO_GEN_SRC + "/org/helloworld/planet/rest/PlanetResourceImpl.java");
 		assertContains(code, "abstract class")
 		assertContains(code, "protected abstract void createRouteDirectCreateForm();")	
-		assertContains(code, ".get(\"/form\").to(\"direct:createForm\")")
+		assertContains(code, "get(\"/form\")")
+		assertContains(code, "to(\"direct:createForm\")")
 	}
 
 
@@ -66,8 +68,7 @@ class ResourceTmplExtensionTest extends GeneratorTestBase {
 	def void assertLibraryResourceImplementation() {
 		val code = getFileText(
 			TO_SRC + "/org/helloworld/planet/rest/PlanetResource.java")
-		// FIXME: No spring @Controller should be present
-		//assertNotContains(code, "@Controller")
+		assertNotContains(code, "@Controller")
 		assertContainsConsecutiveFragments(code, #[
 			"public class PlanetResource extends PlanetResourceImpl {",
 			"public PlanetResource() {",


### PR DESCRIPTION
Implementes basic documentation generation.

This will output either doc written in Sculptor DSL (if present) or generate documentation reflecting operation name, camel route and delegate (if present)

Unfortunately, parameter description is only avialible since Camel 2.16, while Wildfly-Camel subsystem provides Camel 2.15.2.
